### PR TITLE
Add required `await` keyword to awaitable calls

### DIFF
--- a/DawnsburyDaysSummonerClass/SummonerLoader.cs
+++ b/DawnsburyDaysSummonerClass/SummonerLoader.cs
@@ -1013,7 +1013,7 @@ namespace Dawnsbury.Mods.Classes.Summoner {
                     if (qf.Owner.HasEffect(qfReactiveStrikeCheck)) {
                         qf.Owner.RemoveAllQEffects(qf => qf.Id == qfReactiveStrikeCheck);
                         HPShareEffect shareHP = (HPShareEffect)qf.Owner.QEffects.FirstOrDefault<QEffect>((Func<QEffect, bool>)(qf => qf.Id == qfSummonerBond));
-                        HandleHealthShare(qf.Owner, eidolon, shareHP.LoggedAction, SummonerClassEnums.InterceptKind.TARGET);
+                        await HandleHealthShare(qf.Owner, eidolon, shareHP.LoggedAction, SummonerClassEnums.InterceptKind.TARGET);
                     }
 
                     // Handle tempHP
@@ -1554,7 +1554,7 @@ namespace Dawnsbury.Mods.Classes.Summoner {
                         if (qf.Owner.HasEffect(qfReactiveStrikeCheck)) {
                             qf.Owner.RemoveAllQEffects(qf => qf.Id == qfReactiveStrikeCheck);
                             HPShareEffect shareHP = (HPShareEffect)qf.Owner.QEffects.FirstOrDefault<QEffect>((Func<QEffect, bool>)(qf => qf.Id == qfSummonerBond));
-                            HandleHealthShare(qf.Owner, summoner, shareHP.LoggedAction, SummonerClassEnums.InterceptKind.TARGET);
+                            await HandleHealthShare(qf.Owner, summoner, shareHP.LoggedAction, SummonerClassEnums.InterceptKind.TARGET);
                         }
 
                         // Handle tempHP


### PR DESCRIPTION
Async methods must be awaited, otherwise if something awaitable happens within (such as asking a player for a reaction), that reaction box will not pop up and will be ignored, and the rules engine will be confused.